### PR TITLE
fix: Improve determinism and update contenthashes

### DIFF
--- a/testing/src/foo.js
+++ b/testing/src/foo.js
@@ -1,5 +1,7 @@
 import styles from "./foo.module.css";
+import sharedStyles from "./shared.module.css";
 
 export default function foo() {
   console.log(styles.bye);
+  console.log(sharedStyles["another-used-class"]);
 }

--- a/testing/src/index.js
+++ b/testing/src/index.js
@@ -1,6 +1,8 @@
 import styles from "./styles.module.css";
+import sharedStyles from "./shared.module.css";
 
 console.log(styles.used);
+console.log(sharedStyles["some-shared-class"]);
 
 function importFoo() {
   return import(/* webpackChunkName: "foo" */ "./foo");
@@ -8,3 +10,5 @@ function importFoo() {
 
 // Prevent tree-shaking
 window.importFoo = importFoo;
+
+window.alert(styles.someClass + styles.someClassWithASharedPrefix);

--- a/testing/src/shared.module.css
+++ b/testing/src/shared.module.css
@@ -1,0 +1,11 @@
+.some-shared-class {
+    color: blue;
+}
+
+.another-used-class {
+    background: red;
+}
+
+.a-not-used-shared-class {
+    color: pink;
+}

--- a/testing/src/styles.module.css
+++ b/testing/src/styles.module.css
@@ -25,3 +25,11 @@
 .used > .unused {
     background: white;
 }
+
+.someClass {
+    outline: 1px solid black;
+}
+
+.someClassWithASharedPrefix {
+    outline: 1px solid white;
+}


### PR DESCRIPTION
Rather than using the asset index to suffix the classnames, we now use the chunk id (which we collect first in a previous hook).

I also had to add some gross-looking stuff, copied from terser-webpack-plugin and mini-css-webpack-plugin, to ensure that contenthashes are updated when the plugin is enabled. Webpack 4 unfortunately doesn't generate contenthashes based on the actual disk content (!) (https://github.com/webpack/webpack/issues/9520), which means that using a string that represents the plugin is all we can really do. It means that building with/without the plugin enabled (or with different options) should output differently-hashed bundles, which is good for long-term caching.

However, if there are subtle bugs making this plugin not fully deterministic, then we'd output the same hash in error. 

I think this is the best we can do in this plugin, and if consumers require true contenthashes they should use a post-processing plugin which will update filenames accordingly. Webpack 5 may also help with this.

Also fixed a bug with regex over-matching, and added a test.

Closes #3.