### PR TITLE
fix: Ignore assets not part of a chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "1.x",
+    "file-loader": "^4.3.0",
     "jest": "^24.9.0",
     "jsdom": "^15.2.1",
     "mini-css-extract-plugin": "^0.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -123,13 +123,15 @@ async function handleOptimizeAssets(
   const files = Object.keys(assets).filter(fileName => fileName !== "*");
 
   const filesByExt = { js: [], css: [] };
-  files.forEach(file => {
-    if (file.endsWith(".css")) {
-      filesByExt.css.push(file);
-    } else if (file.endsWith(".js")) {
-      filesByExt.js.push(file);
-    }
-  });
+  files
+    .filter(file => fileChunkIdMapping.has(file))
+    .forEach(file => {
+      if (file.endsWith(".css")) {
+        filesByExt.css.push(file);
+      } else if (file.endsWith(".js")) {
+        filesByExt.js.push(file);
+      }
+    });
 
   let seenClasses = [];
   [...filesByExt.css, ...filesByExt.js].forEach((file, index) => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -159,6 +159,22 @@ it("does not match classes over-eagerly", async () => {
   expect(outputMainJs).toContain('"_someClass"');
 });
 
+it("ignores emitted binary assets from file-loader", async () => {
+  // The build shouldn't blow up if we see a file-loader emitted asset, even if
+  // it's js - only process files that are part of the actual chunk
+  const config = generateConfig();
+  config.module.rules.push({
+    test: /vendor.js$/,
+    use: [
+      {
+        loader: "file-loader"
+      }
+    ]
+  });
+
+  await runTestingBuild(config);
+});
+
 describe.each([true, false])("with mangle = %s", mangle => {
   let outputMainJs, outputMainCss, outputFooJs, outputFooCss;
   let allFiles;
@@ -190,6 +206,7 @@ describe.each([true, false])("with mangle = %s", mangle => {
     const { window } = new JSDOM("", {
       runScripts: "dangerously"
     });
+    window.alert = () => {};
     window.console.log = mockConsoleLog;
     window.eval(outputMainJs);
 

--- a/testing/src/index.js
+++ b/testing/src/index.js
@@ -1,5 +1,6 @@
 import styles from "./styles.module.css";
 import sharedStyles from "./shared.module.css";
+import "./vendor.js";
 
 console.log(styles.used);
 console.log(sharedStyles["some-shared-class"]);

--- a/testing/src/vendor.js
+++ b/testing/src/vendor.js
@@ -1,0 +1,1 @@
+// I am an example vendored file


### PR DESCRIPTION
Previously if a js (or css) file was handled via file-loader or similar, and was not actually part of a chunk, we'd process it anyway. This caused errors because the `RawSource` object for the file had its `.source()` as a `Buffer`, which seems incompatible with `ReplaceSource` at the version of webpack-sources that we're using **\***. I *think* it's this issue, for reference: https://github.com/webpack/webpack-sources/issues/26

Anyway - we don't want to handle assets that aren't part of our chunk mapping anyway, since they won't have a chunk id and it doesn't really make sense conceptually.

----

**\*** Looks like the latest version of webpack-sources may fix the issue, but a) it's node 10 only and we support node 8, b) it's still a beta version